### PR TITLE
Solves compilation issue on macOS

### DIFF
--- a/Examples/NAM/get_dsp.cpp
+++ b/Examples/NAM/get_dsp.cpp
@@ -80,13 +80,16 @@ std::unique_ptr<DSP> get_dsp(const std::filesystem::path dirname)
     const bool with_head = config["head"] == NULL;
     const float head_scale = config["head_scale"];
     std::vector<float> params = numpy_util::load_to_vector(dirname / std::filesystem::path("weights.npy"));
+// Solves compilation issue on macOS Error: No matching constructor for initialization of 'wavenet::WaveNet'
+// Solution from https://stackoverflow.com/a/73956681/3768284
+    auto my_json = architecture == "CatWaveNet" ? config["parametric"] : nlohmann::json{};
     return std::make_unique<wavenet::WaveNet>(
-      layer_array_params,
-      head_scale,
-      with_head,
-      architecture == "CatWaveNet" ? config["parametric"] : nlohmann::json{},
-      params
-    );
+          layer_array_params,
+          head_scale,
+          with_head,
+          my_json,
+          params
+        );
   }
   else
   {


### PR DESCRIPTION
Solves compilation error on Mac OS Error: 

No matching constructor for initialization of 'wavenet::WaveNet' In instantiation of function template specialization:

'std::make_unique<wavenet::WaveNet, std::vector<wavenet::LayerArrayParams> &, const float &, const bool &, nlohmann::basic_json<>, std::vector<float> &>'
    
In file included from /Users/username/Dev/iPlug2/Examples/NAM/get_dsp.cpp

note: wavenet.h note: candidate constructor not viable: expects an lvalue for 4th argument
note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 5 were provided
note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 5 were provided'
