### PR TITLE
Replace occurrences of std::exception("message")

### DIFF
--- a/Examples/NAM/dsp.cpp
+++ b/Examples/NAM/dsp.cpp
@@ -165,7 +165,7 @@ Linear::Linear(
 ) : Buffer(receptive_field)
 {
   if (params.size() != (receptive_field + (_bias ? 1 : 0)))
-    throw std::exception("Params vector does not match expected size based on architecture parameters");
+    throw std::runtime_error("Params vector does not match expected size based on architecture parameters");
 
   this->_weight.resize(this->_receptive_field);
   // Pass in in reverse order so that dot products work out of the box.


### PR DESCRIPTION
Can we please change all the occurrences of "std::exception("message")" to "std::runtime_error("message")".  

In macOS I get this error: "No matching conversion for functional-style cast from 'const char[76]' to 'std::exception'" 

Is my understanding that std::exception("message") is another non-standard implementation provided by Microsoft. https://en.cppreference.com/w/cpp/error/exception/exception